### PR TITLE
Add reserved2 field to LightStateLanMessage

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -4,7 +4,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
-	"gopkg.in/lifx-tools/controlifx.v1"
+	"github.com/yath/controlifx"
 	"net"
 	"strconv"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/yath/implifx
+
+go 1.13
+
+require github.com/yath/controlifx v0.0.0-20191027135754-97cac356e3ba

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/yath/controlifx v0.0.0-20191027135754-97cac356e3ba h1:iUtaD4CNFlbZAaGhPzdwtdLyG61oBco84ZSkHP6frZ4=
+github.com/yath/controlifx v0.0.0-20191027135754-97cac356e3ba/go.mod h1:cW5cDf6ONLit6Mej/Qa1vkzI6ihmYvAo89GvBkQY7SA=

--- a/lan.go
+++ b/lan.go
@@ -4,7 +4,7 @@ import (
 	"encoding"
 	"encoding/binary"
 	"fmt"
-	"gopkg.in/lifx-tools/controlifx.v1"
+	"github.com/yath/controlifx"
 	"math"
 )
 

--- a/lan.go
+++ b/lan.go
@@ -327,7 +327,7 @@ func (o EchoResponseLanMessage) MarshalBinary() (data []byte, _ error) {
 }
 
 func (o LightStateLanMessage) MarshalBinary() (data []byte, err error) {
-	data = make([]byte, 44)
+	data = make([]byte, 52)
 
 	// Color.
 	b, err := o.Color.MarshalBinary()
@@ -340,7 +340,7 @@ func (o LightStateLanMessage) MarshalBinary() (data []byte, err error) {
 	binary.LittleEndian.PutUint16(data[10:12], o.Power)
 
 	// Label.
-	copy(data[12:], o.Label)
+	copy(data[12:44], o.Label)
 
 	return
 }


### PR DESCRIPTION
According to [1], the label is followed by another 8 reserved bytes.
At least the Logitech Harmony requires this padding for discovering a
bulb.

1: https://lan.developer.lifx.com/docs/light-messages#section-state-107